### PR TITLE
Changed how the history works

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - production
-  pull_request:
-    branches:
-      production
 
 jobs:
   deploy:

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -37,7 +37,14 @@ class Kernel extends ConsoleKernel
                     $planetModel->fill($planet);
                     $planetModel->save();
 
-                    PlanetHistory::create($planet);
+                    $history = PlanetHistory::orderBy('updated_at', 'DESC')->where('index', $planet['index'])->first();
+
+                    if ($history && $history->toArray() == $planet) {
+                        $history->touch();
+                    } else {
+                        PlanetHistory::create($planet);
+                    }
+
                 }
 
             }

--- a/app/Http/Controllers/Api/PlanetStatusController.php
+++ b/app/Http/Controllers/Api/PlanetStatusController.php
@@ -40,7 +40,7 @@ class PlanetStatusController extends Controller
         $time = Carbon::parse($request->input('time'));
 
         $planets = Planet::with(['history' => function (Builder $q) use ($time) {
-            $q->latest()->where('created_at', '<', $time)->limit(1);
+            $q->latest()->where('updated_at', '<', $time)->limit(1);
         }])->get();
 
         return response()->json($planets->pluck('history')->OneEntryArrayList(), 200);

--- a/app/Models/Planet.php
+++ b/app/Models/Planet.php
@@ -24,6 +24,11 @@ class Planet extends Model
         'created_at'
     ];
 
+    protected $hidden = [
+        'created_at',
+        'index'
+    ];
+
     public function history() {
         return $this->hasMany(PlanetHistory::class, 'index', 'index');
     }

--- a/app/Models/PlanetHistory.php
+++ b/app/Models/PlanetHistory.php
@@ -9,8 +9,6 @@ class PlanetHistory extends Model
 {
     use HasFactory;
 
-    public $timestamps = false;
-
     protected $table = 'planet_histories';
 
     protected $fillable = [
@@ -20,10 +18,7 @@ class PlanetHistory extends Model
         'health',
         'regenPerSecond',
         'players',
-        'created_at'
+        'created_at',
+        'updated_at'
     ];
-
-    // protected $hidden = [
-    //     'id'
-    // ];
 }

--- a/database/migrations/2024_03_27_104500_add_updated_at_to_planet_histories.php
+++ b/database/migrations/2024_03_27_104500_add_updated_at_to_planet_histories.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('planet_histories', function (Blueprint $table) {
+            $table->timestamp('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('planet_histories', function (Blueprint $table) {
+            $table->removeColumn('updated_at');
+        });
+    }
+};

--- a/database/migrations/2024_03_27_123937_fix_regen_columns.php
+++ b/database/migrations/2024_03_27_123937_fix_regen_columns.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('planet_histories', function (Blueprint $table) {
+            $table->decimal('regenPerSecond', 8, 4)->change();
+        });
+
+        Schema::table('planets', function (Blueprint $table) {
+            $table->decimal('regenPerSecond', 8, 4)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('planet_histories', function (Blueprint $table) {
+            $table->float('regenPerSecond', 8, 4)->change();
+        });
+
+        Schema::table('planets', function (Blueprint $table) {
+            $table->float('regenPerSecond', 8, 4)->change();
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -35,12 +35,19 @@ Artisan::command('fetch', function () {
         foreach ($data['planetStatus'] as $planet) {
 
             $planet['warId'] = $currentWarId;
+            $planet['regenPerSecond'] = round($planet['regenPerSecond'], 4);
 
             $planetModel = Planet::firstOrNew(['index' => $planet['index']]);
             $planetModel->fill($planet);
             $planetModel->save();
 
-            PlanetHistory::create($planet);
+            $history = PlanetHistory::orderBy('updated_at', 'DESC')->where('index', $planet['index'])->first();
+
+            if ($history && $history->makeHidden(['created_at', 'updated_at', 'id'])->toArray() == $planet) {
+                $history->touch();
+            } else {
+                PlanetHistory::create($planet);
+            }
         }
 
     }


### PR DESCRIPTION
Changed how the history works to completely remove duplicated entries in the future. Instead of creating a new entry everytime while fetching, the last entry is being checked for differences. If the new fetch is different from the last history, a new entry is created, otherwise `updated_at` is touched, to signal that the entry was created earlier, but is still upto date.